### PR TITLE
chore(ci,docs): simplify Gemini workflow; document auto-merge; fix automerge input

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,4 +27,5 @@ jobs:
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash

--- a/.github/workflows/gemini-recipes.yml
+++ b/.github/workflows/gemini-recipes.yml
@@ -28,8 +28,6 @@ jobs:
     env:
       BATCH_SIZE: ${{ github.event.inputs.batch_size || '5' }}
       GENERATE_EMBEDDINGS: ${{ github.event.inputs.generate_embeddings || 'true' }}
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-      GCP_LOCATION: ${{ vars.GCP_LOCATION || 'global' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,15 +37,11 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Python deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade google-genai pyyaml
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Install Node deps
         run: npm ci
@@ -88,10 +82,10 @@ jobs:
         with:
           branch: chore/gemini-recipes/batch-${{ github.run_number }}
           title: "Gemini: batch de recetas ${{ github.run_number }}"
-          commit-message: "feat(recipes): batch autoeditado y embeddings (Vertex AI)"
+          commit-message: "feat(recipes): batch autoeditado y embeddings (Gemini API)"
           labels: automation, gemini, embeddings
           body: |
             - Lote: ${{ env.BATCH_SIZE }}
-            - Vertex AI: ${{ env.GCP_PROJECT_ID }} / ${{ env.GCP_LOCATION }}
             - Embeddings: ${{ env.GENERATE_EMBEDDINGS }}
+            - Seleccionadas: ${{ steps.select.outputs.selected_count }}
           delete-branch: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,9 @@ python automation/queue/select_batch.py \
 - Branch protection: changes go via PR. Actions and agents create PRs.
 - Keep prompts short. Limit batches to avoid rate limits.
 - Favor idempotent scripts and append-only JSONL artifacts.
+
+## Auto-approve & Auto-merge
+- PRs labeled `automation` are auto-approved by a bot and auto-merge is enabled (squash).
+- Self-approval by the author is blocked by GitHub; the bot handles approval when the label is present.
+- Auto-merge only completes when all required checks are green, respecting branch protection.
+- Workflows: `/.github/workflows/auto-merge.yml` and PR-side helper if needed.


### PR DESCRIPTION
This PR streamlines the Gemini CI and clarifies docs.

Changes:
- Remove unused GCP env and Python deps install in `.github/workflows/gemini-recipes.yml`
- Add Node cache and rely on selector script outputs (selected_count)
- Update PR commit/body to reference Gemini API and selected count
- Fix `.github/workflows/auto-merge.yml` by specifying `pull-request-number`
- Document auto-approve/auto-merge behavior in `AGENTS.md`

Labels: automation, gemini, ci, docs

Once checks pass, auto-approve + auto-merge (squash) should engage for the `automation` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a “Auto-approve & Auto-merge” section explaining how labeled PRs are auto-approved and merged (squash) once checks pass.

- Chores
  - Improved auto-merge workflow reliability by explicitly passing the PR number to the merge action.
  - Simplified the recipes workflow by removing Vertex AI-specific settings and Python dependency installation.
  - Enabled npm caching to speed up runs.
  - Updated PR messages to reference Gemini API and enhanced PR body to display the count of selected files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->