### PR TITLE
ci: fix auto-merge workflows by providing pull-request-number input

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           merge-method: squash
+          pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This PR fixes failing auto-merge workflows.

Problem:
- `peter-evans/enable-pull-request-automerge@v3` was invoked without `pull-request-number`.
- The action defaulted to `gh pr merge ... ""` (empty PR), causing:
  `could not determine current branch: fatal: not a git repository`

Fix:
- Explicitly set `pull-request-number: ${{ github.event.pull_request.number }}` in both workflows:
  - `.github/workflows/auto-merge.yml`
  - `.github/workflows/auto-merge-pr.yml`

Notes:
- Permissions unchanged (contents: write, pull-requests: write).
- Keep `merge-method: squash`.

After merge:
- New PRs labeled `automation` should auto-approve and properly enable auto-merge without errors.